### PR TITLE
Add shader variant API and gradient palette controls

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 """FastAPI application for the wallpaper generator."""
 from __future__ import annotations
 
+import base64
 import json
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -12,7 +13,26 @@ from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from .config import Settings, get_settings
+from .shaders import SHADER_VARIANTS
 from .telemetry import TelemetryEvent, TelemetryStore
+
+
+FAVICON_BYTES = base64.b64decode(
+    (
+        "AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAQAQAAAAAAAAAAAAAAAAAAAAAAADikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQ"
+        "Sv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQ"
+        "Sv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQ"
+        "Sv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQ"
+        "Sv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQ"
+        "Sv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQ"
+        "Sv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQ"
+        "Sv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQ"
+        "Sv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQ"
+        "Sv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQ"
+        "Sv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQ"
+        "Sv/ikEr/4pBK/+KQSv/ikEr/4pBK/+KQSv/ikEr/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+    )
+)
 
 
 def _ensure_static_root(path: Path) -> Path:
@@ -88,6 +108,14 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
         if not sw_path.exists():
             raise HTTPException(status_code=404, detail="Service worker not found")
         return FileResponse(sw_path, media_type="application/javascript")
+
+    @app.get("/favicon.ico")
+    async def favicon() -> Response:
+        return Response(content=FAVICON_BYTES, media_type="image/x-icon")
+
+    @app.get("/api/shaders")
+    async def shaders() -> Response:
+        return JSONResponse(content=SHADER_VARIANTS)
 
     @app.post("/api/telemetry")
     async def telemetry(request: Request, current_settings: Settings = Depends(get_settings)) -> Dict[str, Any]:

--- a/app/shaders.py
+++ b/app/shaders.py
@@ -1,0 +1,40 @@
+"""Shader variant catalog served to the front end."""
+
+from __future__ import annotations
+
+from typing import List, TypedDict
+
+
+class ShaderVariant(TypedDict):
+    id: str
+    name: str
+    description: str
+    default_strength: float
+
+
+SHADER_VARIANTS: List[ShaderVariant] = [
+    {
+        "id": "classic",
+        "name": "Classic Gradient",
+        "description": "Baseline renderer that blends the base fill with the configured gradient.",
+        "default_strength": 0.0,
+    },
+    {
+        "id": "lumina",
+        "name": "Lumina Bloom",
+        "description": "Adds a soft, center-weighted bloom that enhances luminous gradients and pastel palettes.",
+        "default_strength": 0.55,
+    },
+    {
+        "id": "nocturne",
+        "name": "Nocturne Veil",
+        "description": "Cools midtones and lifts highlights for moody, night-inspired backgrounds.",
+        "default_strength": 0.65,
+    },
+    {
+        "id": "ember",
+        "name": "Ember Drift",
+        "description": "Warms the outer edge with ember-like glow for dramatic contrast.",
+        "default_strength": 0.5,
+    },
+]

--- a/static/js/state.js
+++ b/static/js/state.js
@@ -3,12 +3,17 @@ export const MAX_GRADIENT_STOPS = 8;
 export const defaultState = Object.freeze({
   canvas: { width: 1920, height: 1080, previewScale: 0.5 },
   color: { hue: 210, saturation: 0.55, lightness: 0.45, gamma: 1.0 },
+  rendering: {
+    shader: 'classic',
+    shaderStrength: 0.5,
+  },
   gradient: {
     type: 'radial',
     mode: 'continuous',
     angle: 45,
     center: { x: 0.5, y: 0.5 },
     scale: 1.0,
+    palette: { hue: 210, saturation: 0.6, lightness: 0.5 },
     stops: [
       { pos: 0.0, hueShift: 0.0, lightnessDelta: 0.0, opacity: 1.0 },
       { pos: 1.0, hueShift: 30.0, lightnessDelta: 0.25, opacity: 0.6 },
@@ -31,12 +36,10 @@ export const defaultState = Object.freeze({
   output: { format: 'png', jpgQuality: 0.92, embedMetadata: true },
 });
 
+export { clamp } from './utils.js';
+
 export function cloneState(state) {
   return structuredClone(state);
-}
-
-export function clamp(value, min, max) {
-  return Math.min(Math.max(value, min), max);
 }
 
 export function randomSeed() {

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -1,3 +1,7 @@
+export function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
 export function hslToRgb(h, s, l) {
   const hue = ((h % 360) + 360) % 360;
   const c = (1 - Math.abs(2 * l - 1)) * s;


### PR DESCRIPTION
## Summary
- expose a JSON shader catalog endpoint and serve the favicon inline without bundling binary assets
- add shader selection, strength, and gradient palette controls to the UI with corresponding renderer and shader updates
- cover the new shader catalog and favicon handling in the FastAPI test suite

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc819aa91483309758e756d3ec02f3