### PR TITLE
Refactor renderer to avoid WebGL fallbacks

### DIFF
--- a/static/js/context.js
+++ b/static/js/context.js
@@ -1,0 +1,20 @@
+const CANVAS_OPTIONS = {
+  willReadFrequently: false,
+  desynchronized: false,
+  alpha: true,
+};
+
+export function createCanvas2DContext(canvas) {
+  if (!canvas) {
+    console.warn('Canvas element not provided.');
+    return null;
+  }
+
+  const context = canvas.getContext('2d', CANVAS_OPTIONS);
+  if (!context) {
+    console.warn('Canvas2D context unavailable; rendering cannot proceed without it.');
+    return null;
+  }
+
+  return context;
+}

--- a/static/js/renderer.js
+++ b/static/js/renderer.js
@@ -1,3 +1,4 @@
+import { createCanvas2DContext } from './context.js';
 import { cloneState } from './state.js';
 import { clamp, downloadBlob, formatDimension, hslToRgb, toast } from './utils.js';
 
@@ -122,12 +123,9 @@ export class WallpaperRenderer {
   constructor(canvas, initialState) {
     this.canvas = canvas;
     this.state = cloneState(initialState);
-    this.canvas2d = this.canvas?.getContext('2d') ?? null;
-    if (!this.canvas2d) {
-      console.warn('Unable to initialize Canvas2D rendering context');
-    }
+    this.canvas2d = createCanvas2DContext(this.canvas);
     this.bufferCanvas = document.createElement('canvas');
-    this.bufferCtx = this.bufferCanvas.getContext('2d');
+    this.bufferCtx = createCanvas2DContext(this.bufferCanvas);
     this.previewZoom = 1;
     this.previewOffset = { x: 0, y: 0 };
     this.dragging = false;
@@ -228,7 +226,7 @@ export class WallpaperRenderer {
     if (this.bufferCanvas.width !== width || this.bufferCanvas.height !== height) {
       this.bufferCanvas.width = width;
       this.bufferCanvas.height = height;
-      this.bufferCtx = this.bufferCanvas.getContext('2d');
+      this.bufferCtx = createCanvas2DContext(this.bufferCanvas);
       this.wallpaperDirty = true;
     }
   }
@@ -273,9 +271,8 @@ export class WallpaperRenderer {
       ctx.restore();
       return;
     }
-    const ctx = targetCanvas.getContext('2d');
+    const ctx = createCanvas2DContext(targetCanvas);
     if (!ctx) {
-      console.warn('Canvas2D context unavailable for rendering');
       return;
     }
     ctx.save();
@@ -487,7 +484,10 @@ export class WallpaperRenderer {
     const canvas = document.createElement('canvas');
     canvas.width = state.canvas.width;
     canvas.height = state.canvas.height;
-    const ctx = canvas.getContext('2d');
+    const ctx = createCanvas2DContext(canvas);
+    if (!ctx) {
+      throw new Error('Canvas2D context unavailable for rendering');
+    }
     this.paintWallpaper(ctx, canvas.width, canvas.height, cloneState(state));
     const type = format === 'png' ? 'image/png' : format === 'webp' ? 'image/webp' : 'image/jpeg';
     const quality = format === 'jpg' ? state.output.jpgQuality : undefined;

--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -5,6 +5,7 @@ const ASSETS = [
   '/static/css/app.css',
   '/static/js/main.js',
   '/static/js/controls.js',
+  '/static/js/context.js',
   '/static/js/state.js',
   '/static/js/utils.js',
   '/static/js/renderer.js',

--- a/tests/test_frontend_assets.py
+++ b/tests/test_frontend_assets.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def test_context_helper_is_canvas_only():
+    context_path = Path('static/js/context.js')
+    assert context_path.exists(), 'Canvas context helper should exist'
+    content = context_path.read_text('utf-8')
+    lowered = content.lower()
+    assert 'createcanvas2dcontext' in lowered
+    assert "getcontext('2d'" in lowered or 'getcontext("2d"' in lowered
+    assert 'webgl' not in lowered
+
+
+def test_renderer_avoids_webgl_references():
+    renderer_path = Path('static/js/renderer.js')
+    content = renderer_path.read_text('utf-8').lower()
+    assert 'webgl' not in content


### PR DESCRIPTION
## Summary
- add a reusable Canvas2D context helper and route the renderer through it
- ensure the service worker precaches the new module for offline support
- add tests that assert the canvas helper and renderer stay free of WebGL dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc99fc31988330a481db9e67e35293