### PR TITLE
Coalesce slider history entries and keep settings panels open

### DIFF
--- a/tests/test_frontend_assets.py
+++ b/tests/test_frontend_assets.py
@@ -43,3 +43,16 @@ def test_history_entries_expose_actions():
     content = presets_path.read_text('utf-8')
     assert 'Reapply' in content
     assert 'Remove' in content
+
+
+def test_main_avoids_duplicate_hash_renders():
+    main_path = Path('static/js/main.js')
+    content = main_path.read_text('utf-8')
+    assert 'stateFingerprint(state) === stateFingerprint(currentState)' in content
+
+
+def test_main_coalesces_history_updates():
+    main_path = Path('static/js/main.js')
+    content = main_path.read_text('utf-8')
+    assert 'queueHistoryEntry' in content
+    assert 'pendingHistorySnapshot' in content


### PR DESCRIPTION
## Summary
- debounce history updates so slider drags produce a single "Adjusted" entry
- ignore redundant hashchange events to avoid re-rendering and collapsing open accordion sections
- assert new frontend safeguards in regression tests

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddb99ee8388330981d09f8c4f8d09a