### PR TITLE
Add effect toggles and improve presets collapse behavior

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -22,6 +22,22 @@ body {
   padding-right: 0.5rem;
 }
 
+#presets-panel.collapsed #presets-list,
+#presets-panel.collapsed .history {
+  display: none;
+}
+
+#presets-panel.collapsed {
+  flex: 0 0 auto;
+  width: auto !important;
+  padding-right: 0;
+  max-height: none;
+}
+
+#presets-panel.collapsed > .d-flex {
+  margin-bottom: 0;
+}
+
 .list-group-item {
   cursor: pointer;
 }
@@ -68,6 +84,19 @@ input[type="color"] {
 }
 
 .stop-item .btn {
+  font-size: 0.75rem;
+}
+
+.accordion-item.section-disabled .accordion-body {
+  opacity: 0.5;
+}
+
+.accordion-item.section-disabled .accordion-body,
+.accordion-item.section-disabled .accordion-body * {
+  pointer-events: none;
+}
+
+.accordion-header .section-toggle .form-check-label {
   font-size: 0.75rem;
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -43,7 +43,7 @@
         <aside class="col-lg-3" id="presets-panel">
           <div class="d-flex justify-content-between align-items-center mb-2">
             <h2 class="h5 mb-0">Presets</h2>
-            <button class="btn btn-sm btn-outline-light" id="toggle-presets">Toggle</button>
+            <button class="btn btn-sm btn-outline-light" id="toggle-presets">Hide</button>
           </div>
           <div id="presets-list" class="list-group small"></div>
           <div class="history mt-3">

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -238,10 +238,18 @@ function bindUi() {
     });
   }
 
-  togglePresets.addEventListener('click', () => {
-    const panel = document.getElementById('presets-panel');
-    panel.classList.toggle('d-none');
-  });
+  if (togglePresets) {
+    togglePresets.setAttribute('aria-controls', 'presets-panel');
+    togglePresets.setAttribute('aria-expanded', 'true');
+    togglePresets.textContent = 'Hide';
+    togglePresets.addEventListener('click', () => {
+      const panel = document.getElementById('presets-panel');
+      if (!panel) return;
+      const collapsed = panel.classList.toggle('collapsed');
+      togglePresets.textContent = collapsed ? 'Show' : 'Hide';
+      togglePresets.setAttribute('aria-expanded', String(!collapsed));
+    });
+  }
 
   updateDownloadAvailability();
 }

--- a/static/js/renderer.js
+++ b/static/js/renderer.js
@@ -292,7 +292,8 @@ export class WallpaperRenderer {
     ctx.fillStyle = `hsl(${baseHue}, ${baseSat}%, ${baseLight}%)`;
     ctx.fillRect(0, 0, width, height);
     const palette = this.getGradientPalette(state);
-    if (state.gradient.type !== 'none') {
+    const gradientEnabled = state.gradient?.enabled !== false;
+    if (gradientEnabled && state.gradient.type !== 'none') {
       const gradient = this.createCanvasGradient(ctx, width, height, state.gradient, palette);
       if (gradient) {
         ctx.globalCompositeOperation = mapBlendToComposite(state.gradient.blend);
@@ -320,6 +321,9 @@ export class WallpaperRenderer {
   }
 
   applyShaderVariantFallback(ctx, width, height, state, palette) {
+    if (state.rendering?.enabled === false) {
+      return;
+    }
     const variant = state.rendering?.shader || 'classic';
     const strength = clamp(state.rendering?.shaderStrength ?? 0, 0, 1);
     if (variant === 'classic' || strength <= 0) {
@@ -442,6 +446,9 @@ export class WallpaperRenderer {
   }
 
   applyNoise(ctx, width, height, state) {
+    if (state.grain?.enabled === false) {
+      return;
+    }
     const amount = clamp(state.grain.amount, 0, 100);
     if (amount <= 0) return;
     const samples = Math.floor(width * height * (amount / 5000));
@@ -458,6 +465,9 @@ export class WallpaperRenderer {
   }
 
   applyVignette(ctx, width, height, vignetteState) {
+    if (vignetteState?.enabled === false) {
+      return;
+    }
     const strength = clamp(vignetteState?.strength ?? 0, 0, 1);
     if (strength <= 0) return;
     const radius = clamp(vignetteState.radius ?? 0.8, 0.1, 2);

--- a/static/js/state.js
+++ b/static/js/state.js
@@ -4,10 +4,12 @@ export const defaultState = Object.freeze({
   canvas: { width: 1920, height: 1080, previewScale: 0.5 },
   color: { hue: 210, saturation: 0.55, lightness: 0.45, gamma: 1.0 },
   rendering: {
+    enabled: true,
     shader: 'classic',
     shaderStrength: 0.5,
   },
   gradient: {
+    enabled: true,
     type: 'radial',
     mode: 'continuous',
     angle: 45,
@@ -21,6 +23,7 @@ export const defaultState = Object.freeze({
     blend: 'overlay',
   },
   grain: {
+    enabled: true,
     amount: 35,
     size: 'normal',
     algorithm: 'fbm',
@@ -31,7 +34,7 @@ export const defaultState = Object.freeze({
     intensityCurve: 's-curve',
     protectShadows: 0.05,
   },
-  vignette: { strength: 0.4, radius: 0.8, feather: 0.6, roundness: 1.0, mode: 'multiply' },
+  vignette: { enabled: true, strength: 0.4, radius: 0.8, feather: 0.6, roundness: 1.0, mode: 'multiply' },
   random: { seed: Math.floor(Math.random() * 2 ** 32) >>> 0 },
   output: { format: 'png', jpgQuality: 0.92, embedMetadata: true },
 });

--- a/tests/test_frontend_assets.py
+++ b/tests/test_frontend_assets.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 
 
 def test_context_helper_is_canvas_only():
@@ -38,6 +39,13 @@ def test_controls_sections_allow_multiple_open():
     assert 'dataset.bsParent' not in content
 
 
+def test_controls_sections_expose_effect_toggles():
+    controls_path = Path('static/js/controls.js')
+    content = controls_path.read_text('utf-8')
+    assert 'section-toggle' in content
+    assert 'setSectionDisabled' in content
+
+
 def test_history_entries_expose_actions():
     presets_path = Path('static/js/presets.js')
     content = presets_path.read_text('utf-8')
@@ -56,3 +64,27 @@ def test_main_coalesces_history_updates():
     content = main_path.read_text('utf-8')
     assert 'queueHistoryEntry' in content
     assert 'pendingHistorySnapshot' in content
+
+
+def test_default_state_includes_effect_toggles():
+    state_path = Path('static/js/state.js')
+    content = state_path.read_text('utf-8')
+    for section in ('rendering', 'gradient', 'grain', 'vignette'):
+        pattern = rf"{section}:\s*{{.*?enabled:\s*true"
+        assert re.search(pattern, content, flags=re.DOTALL), f"{section} section should default to enabled"
+
+
+def test_renderer_honors_effect_toggles():
+    renderer_path = Path('static/js/renderer.js')
+    content = renderer_path.read_text('utf-8')
+    assert 'state.rendering?.enabled' in content
+    assert 'state.gradient?.enabled' in content
+    assert 'state.grain?.enabled' in content
+    assert 'vignetteState?.enabled' in content
+
+
+def test_presets_panel_toggle_preserves_button():
+    main_path = Path('static/js/main.js')
+    content = main_path.read_text('utf-8')
+    assert "panel.classList.toggle('collapsed')" in content
+    assert "togglePresets.textContent = collapsed ? 'Show' : 'Hide'" in content


### PR DESCRIPTION
## Summary
- add enable/disable toggles for rendering, gradient, grain, and vignette sections with shared state
- respect section enablement in rendering/state handling and keep the presets control accessible when collapsed
- update styling and tests to cover the new toggles and presets panel behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddbd88302c833099f82d3e39266a37