### PR TITLE
Improve gradient controls and add tooltips

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -67,6 +67,26 @@ input[type="color"] {
   width: 5rem;
 }
 
+.setting-label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.setting-description {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.65);
+  margin-top: 0.25rem;
+}
+
+.form-check .setting-description {
+  margin-left: 2.5rem;
+}
+
+.color-preview {
+  color: rgba(255, 255, 255, 0.85);
+}
+
 .stop-list {
   display: flex;
   flex-direction: column;

--- a/tests/test_frontend_assets.py
+++ b/tests/test_frontend_assets.py
@@ -46,6 +46,25 @@ def test_controls_sections_expose_effect_toggles():
     assert 'setSectionDisabled' in content
 
 
+def test_flat_gradient_type_listed():
+    controls_path = Path('static/js/controls.js')
+    content = controls_path.read_text('utf-8')
+    assert "const GRADIENT_TYPES = ['flat'" in content
+
+
+def test_renderer_normalizes_flat_gradient():
+    renderer_path = Path('static/js/renderer.js')
+    content = renderer_path.read_text('utf-8')
+    assert "state.gradient?.type === 'none' ? 'flat'" in content
+    assert "type === 'flat'" in content
+
+
+def test_setting_description_styles_present():
+    css_path = Path('static/css/app.css')
+    content = css_path.read_text('utf-8')
+    assert '.setting-description' in content
+
+
 def test_history_entries_expose_actions():
     presets_path = Path('static/js/presets.js')
     content = presets_path.read_text('utf-8')


### PR DESCRIPTION
## Summary
- treat a solid color as a new `flat` gradient type, moving base color controls into the gradient section and hiding irrelevant fields per selection
- add contextual descriptions for every control with supporting styles and conditional visibility for shader, grain, and output options
- normalize the renderer for the new gradient mode and extend frontend tests to cover the updated UI assets

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddc53c84a88330bb80093e8588a3cb